### PR TITLE
Add material reference syntax highlighting configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,3 +41,12 @@ theme:
 
 extra_css:
   - stylesheets/extra.css
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences


### PR DESCRIPTION
Configuration from https://squidfunk.github.io/mkdocs-material/reference/code-blocks/ to make syntax highlighting work